### PR TITLE
thermanager: Update backlight values and enable it

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -29,10 +29,7 @@
 		</resource>
 
 		<!-- device-specific -->
-		<!-- XXX: driver broken:
 		<resource name="backlight" type="sysfs">/sys/class/leds/wled:backlight/max_brightness</resource>
-		-->
-		<resource name="backlight" type="echo" />
 
 		<resource name="temp-emmc" type="msm-adc">/sys/devices/qpnp-vadc-e4910000/emmc_therm</resource>
 		<resource name="temp-batt" type="msm-adc">/sys/devices/qpnp-vadc-e4910000/batt_therm</resource>
@@ -118,10 +115,10 @@
 	</control>
 
 	<control name="backlight">
-		<mitigation level="off"><value resource="backlight">4095</value></mitigation>
-		<mitigation level="1"><value resource="backlight">3200</value></mitigation>
-		<mitigation level="2"><value resource="backlight">2400</value></mitigation>
-		<mitigation level="3"><value resource="backlight">1600</value></mitigation>
+		<mitigation level="off"><value resource="backlight">255</value></mitigation>
+		<mitigation level="1"><value resource="backlight">200</value></mitigation>
+		<mitigation level="2"><value resource="backlight">150</value></mitigation>
+		<mitigation level="3"><value resource="backlight">100</value></mitigation>
 	</control>
 
 	<control name="gpu">


### PR DESCRIPTION
- Scale the values with max as 2^8 instead of 2^12, as the
  kernel driver handles that.
- Needs: https://github.com/sonyxperiadev/kernel/pull/87
