### PR TITLE
togari: re-add audio route for Telephony tx/rx

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -498,6 +498,17 @@
         <path name="voice-call bt-sco" />
     </path>
 
+    <path name="voice-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
+    </path>
+
+    <path name="afe-proxy-playback afe-proxy">
+    </path>
+
+    <path name="afe-proxy-record afe-proxy">
+    </path>
+
     <path name="voice-call usb-headphones">
         <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
         <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
@@ -1815,6 +1826,12 @@
     <path name="listen-handset-mic">
         <ctl name="MADONOFF Switch" value="1" />
         <ctl name="MAD Input" value="DMIC1" />
+    </path>
+
+    <path name="voice-rx">
+    </path>
+
+    <path name="voice-tx">
     </path>
 
 </mixer>


### PR DESCRIPTION
Google Dialer app: 05-03 15:06:12.995 D/audio_hw_primary(335): out_set_parameters: enter: usecase(20: afe-proxy-playback) kvpairs: routing=0

was removed in commit: 5c23b68

Signed-off-by: David Viteri davidteri91@gmail.com
